### PR TITLE
Add support for request properties as additional state

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,8 @@ passport.use(
       clientSecret: "my-oidc-client-secret",
       callbackURL: "https://my-client-endpoint.com/auth/callback",
       scope: "openid", // Optional values from OIDC spec: profile, email, address, phone
-      pkce: "S256" // Include to perform Proof Key Code Exchange else ignore. Possible values are "S256" || "plain"
+      pkce: "S256" // Optional. Include to perform Proof Key Code Exchange else ignore. Possible values are "S256" || "plain"
+      extraState: "query" // Optional. Extra state from the original auth request that will be sent back in the callback's request.query.state as a json string. Possible values are default properties in req such as path, params, query or any custom properties you assign into req
     },
     async (
       issuer,

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ passport.use(
       callbackURL: "https://my-client-endpoint.com/auth/callback",
       scope: "openid", // Optional values from OIDC spec: profile, email, address, phone
       pkce: "S256" // Optional. Include to perform Proof Key Code Exchange else ignore. Possible values are "S256" || "plain"
-      extraState: "query" // Optional. Extra state from the original auth request that will be sent back in the callback's request.query.state as a json string. Possible values are default properties in req such as path, params, query or any custom properties you assign into req
+      originalReqProp: "query" // Optional. Extra state from any properties in the original auth request which will be sent back in the callback's request.query.state as a json string. Possible values are default properties in req such as path, params, query or any custom properties you assign into req
     },
     async (
       issuer,

--- a/lib/setup/manual.js
+++ b/lib/setup/manual.js
@@ -12,7 +12,8 @@ exports = module.exports = function(options) {
       clientID: options.clientID,
       clientSecret: options.clientSecret,
       callbackURL: options.callbackURL,
-      pkce: options.pkce
+      pkce: options.pkce,
+      originalReqProp: options.originalReqProp
     }
 
     Object.keys(options).map(opt => {

--- a/lib/state/session.js
+++ b/lib/state/session.js
@@ -35,16 +35,20 @@ function SessionStore(options) {
  * @param {Function} callback
  * @api protected
  */
-SessionStore.prototype.store = function(req, meta, extraState, callback) {
+SessionStore.prototype.store = function(req, meta, callback) {
   if (!req.session) { return callback(new Error('OpenID Connect authentication requires session support when using state. Did you forget to use express-session middleware?')); }
 
   var key = this._key;
 
-  var handle = JSON.stringify({
-    extraState: req[extraState],
+  var handle = {
     handle : utils.uid(24)
-  })
-  var state = { handle: handle };
+  }
+  if(meta.originalReqProp){
+    handle.originalReqProp = req[meta.originalReqProp]
+  }
+  handle = JSON.stringify(handle)
+
+  var state = { handle };
   for (entry in meta) {
     state[entry] = meta[entry];
   }

--- a/lib/state/session.js
+++ b/lib/state/session.js
@@ -35,12 +35,15 @@ function SessionStore(options) {
  * @param {Function} callback
  * @api protected
  */
-SessionStore.prototype.store = function(req, meta, callback) {
+SessionStore.prototype.store = function(req, meta, extraState, callback) {
   if (!req.session) { return callback(new Error('OpenID Connect authentication requires session support when using state. Did you forget to use express-session middleware?')); }
 
   var key = this._key;
-  var handle = utils.uid(24);
 
+  var handle = JSON.stringify({
+    extraState: req[extraState],
+    handle : utils.uid(24)
+  })
   var state = { handle: handle };
   for (entry in meta) {
     state[entry] = meta[entry];

--- a/lib/strategy.js
+++ b/lib/strategy.js
@@ -44,6 +44,7 @@ function Strategy(options, verify) {
     this.name + ":" + url.parse(options.authorizationURL).hostname;
   this._stateStore = options.store || new SessionStateStore({ key: this._key });
 
+  this._extraState = options.extraState
   if (options.authorizationURL && options.tokenURL) {
     // This OpenID Connect strategy is configured to work with a specific
     // provider.  Override the discovery process with pre-configured endpoints.
@@ -574,8 +575,8 @@ Strategy.prototype.authenticate = function(req, options) {
 
       try {
         var arity = self._stateStore.store.length;
-        if (arity == 3) {
-          self._stateStore.store(req, meta, stored);
+        if (arity == 4) {
+          self._stateStore.store(req, meta, self._extraState, stored);
         } else {
           // arity == 2
           self._stateStore.store(req, stored);

--- a/lib/strategy.js
+++ b/lib/strategy.js
@@ -44,7 +44,6 @@ function Strategy(options, verify) {
     this.name + ":" + url.parse(options.authorizationURL).hostname;
   this._stateStore = options.store || new SessionStateStore({ key: this._key });
 
-  this._extraState = options.extraState
   if (options.authorizationURL && options.tokenURL) {
     // This OpenID Connect strategy is configured to work with a specific
     // provider.  Override the discovery process with pre-configured endpoints.
@@ -574,9 +573,9 @@ Strategy.prototype.authenticate = function(req, options) {
       }
 
       try {
-        var arity = self._stateStore.store.length;
-        if (arity == 4) {
-          self._stateStore.store(req, meta, self._extraState, stored);
+        var arity = self._stateStore.store.length; 
+        if (arity == 3) {
+          self._stateStore.store(req, meta, stored);
         } else {
           // arity == 2
           self._stateStore.store(req, stored);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@techpass/passport-openidconnect",
-  "version": "0.2.6",
+  "version": "0.3.0",
   "description": "OpenID Connect authentication strategy for Passport.",
   "keywords": [
     "auth",


### PR DESCRIPTION
Adding **extraState** option to allow passing any properties in the original auth request object as additional state to be pass through the oauth flow.  Will be sent back in request.query.state as a jsonstring in the callback uri.