### PR TITLE
Fix typo in oauth Profile interface

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -353,7 +353,7 @@ declare namespace OpenIDConnectStrategy {
         /** User preferred_name in jwt claim */
         username?: string;
         name?: {
-            giveName?: string;
+            givenName?: string;
             familyName?: string;
             middleName?: string;
         };


### PR DESCRIPTION
# Description

The correct property is givenName

## Type of change

Please check on the checkbox for those that are relevant (put x between the brackets)

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Code enhancement and update (non-breaking change)
- [ ] Security patch